### PR TITLE
Add CI testing with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+dist: trusty
+sudo: false
+addons:
+  chrome: stable
+cache:
+  npm: true
+  directories:
+    - node_modules
+node_js:
+  - 8

--- a/karma-ci.conf.js
+++ b/karma-ci.conf.js
@@ -1,0 +1,32 @@
+// Karma configuration for CI testing
+
+module.exports =
+  function(config) {
+    config.set({
+        basePath: '',
+        frameworks: ['jasmine'],
+        files: [
+            'node_modules/leaflet/dist/leaflet.js',
+            'node_modules/d3/build/d3.js',
+            'node_modules/geotiff/dist/geotiff.browserify.js',
+            'dist/leaflet.canvaslayer.field.js',
+            {
+                pattern: 'docs/data/*.{asc,tiff,tif}',
+                watched: true,
+                included: false,
+                served: true
+            },
+            'spec/**/*Spec.js'
+        ],
+        exclude: [],
+        preprocessors: {},
+        reporters: ['progress'],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: false,
+        browsers: ['ChromeHeadless'],
+        singleRun: true,
+        concurrency: Infinity
+    });
+};

--- a/karma-local.conf.js
+++ b/karma-local.conf.js
@@ -1,0 +1,65 @@
+// Karma configuration for local testing
+
+module.exports =
+  function(config) {
+    config.set({
+        // base path that will be used to resolve all patterns (eg. files, exclude)
+        basePath: '',
+
+        // frameworks to use
+        // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+        frameworks: ['jasmine'],
+
+        // list of files / patterns to load in the browser
+        files: [
+            'node_modules/leaflet/dist/leaflet.js',
+            'node_modules/d3/build/d3.js',
+            'node_modules/geotiff/dist/geotiff.browserify.js',
+            'dist/leaflet.canvaslayer.field.js',
+            {
+                pattern: 'docs/data/*.{asc,tiff,tif}',
+                watched: true,
+                included: false,
+                served: true
+            },
+            'spec/**/*Spec.js'
+        ],
+
+        // list of files to exclude
+        exclude: [],
+
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {},
+
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress'],
+
+        // web server port
+        port: 9876,
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
+
+        // start these browsers
+        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        browsers: ['Chrome'],
+
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: false,
+
+        // Concurrency level
+        // how many browser should be started simultaneous
+        concurrency: Infinity
+    });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,65 +1,9 @@
+//
 // Karma configuration
-// Generated on Mon Sep 18 2017 22:01:04 GMT+0200 (CEST)
+//
+// Conditionally load local or CI configurations based on CI environment variable
+//
 
-module.exports = function(config) {
-    config.set({
-        // base path that will be used to resolve all patterns (eg. files, exclude)
-        basePath: '',
-
-        // frameworks to use
-        // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-        frameworks: ['jasmine'],
-
-        // list of files / patterns to load in the browser
-        files: [
-            'node_modules/leaflet/dist/leaflet.js',
-            'node_modules/d3/build/d3.js',
-            'node_modules/geotiff/dist/geotiff.browserify.js',
-            'dist/leaflet.canvaslayer.field.js',
-            {
-                pattern: 'docs/data/*.{asc,tiff,tif}',
-                watched: true,
-                included: false,
-                served: true
-            },
-            'spec/**/*Spec.js'
-        ],
-
-        // list of files to exclude
-        exclude: [],
-
-        // preprocess matching files before serving them to the browser
-        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-        preprocessors: {},
-
-        // test results reporter to use
-        // possible values: 'dots', 'progress'
-        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['progress'],
-
-        // web server port
-        port: 9876,
-
-        // enable / disable colors in the output (reporters and logs)
-        colors: true,
-
-        // level of logging
-        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-        logLevel: config.LOG_INFO,
-
-        // enable / disable watching file and executing tests whenever any file changes
-        autoWatch: true,
-
-        // start these browsers
-        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['Chrome'],
-
-        // Continuous Integration mode
-        // if true, Karma captures browsers, runs the tests and exits
-        singleRun: false,
-
-        // Concurrency level
-        // how many browser should be started simultaneous
-        concurrency: Infinity
-    });
-};
+module.exports = process.env.CI === 'true'
+  ? require( './karma-ci.conf.js' )
+  : require( './karma-local.conf.js' );

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "leaflet-canvaslayer-field",
     "version": "1.3.4",
-    "description":
-        "A set of layers using canvas to draw ASCIIGrid or GeoTIFF files. This includes a basic raster layer (*ScalaField*) and an animated layer for vector fields, such as wind or currents (*VectorFieldAnim*)",
+    "description": "A set of layers using canvas to draw ASCIIGrid or GeoTIFF files. This includes a basic raster layer (*ScalaField*) and an animated layer for vector fields, such as wind or currents (*VectorFieldAnim*)",
     "main": "index.js",
     "dependencies": {
         "npm": "^3.10.7",
@@ -32,10 +31,10 @@
         "webpack-shell-plugin": "^0.5.0"
     },
     "scripts": {
-        "start": "node_modules/.bin/webpack --watch",
-        "build": "node_modules/.bin/webpack -p",
-        "web": "node_modules/.bin/webpack-dev-server",
-        "test": "node_modules/.bin/karma start"
+        "start": "webpack --watch",
+        "build": "webpack -p",
+        "web": "webpack-dev-server",
+        "test": "karma start"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
[Travis](https://travis-ci.org/) offers free Continuous Integration testing for open source projects.

This PR makes the relevant changes to take advantage of Travis for CI testing:
- Add `.travis.yml` configuration file
- Make Karma test configuration depend on environment
- Add CI Karma configuration

Additionally, this PR removes `node_modules/.bin/` from npm scripts as npm automatically includes this path when executing scripts like `npm run build`.

## Testing
1. Local testing should remain unchanged. Verify that `npm test` continues to work as before.
1. Travis testing should be available. Sign in to [Travis](https://travis-ci.org) with your GitHub account and activate this Repo.
1. You can verify [travis testing on my fork](https://travis-ci.org/sirreal/Leaflet.CanvasLayer.Field/branches), I've added a branch with broken tests `try/ci-break-test`.

## Follow-up
Add a [build status badge](https://docs.travis-ci.com/user/status-images/) 😎 