### PR TITLE
Size of grid points as a parameter

### DIFF
--- a/src/layer/L.CanvasLayer.SimpleLonLat.js
+++ b/src/layer/L.CanvasLayer.SimpleLonLat.js
@@ -5,7 +5,8 @@
  */
 L.CanvasLayer.SimpleLonLat = L.CanvasLayer.extend({
     options: {
-        color: 'gray'
+        color: 'gray',
+        size: 2
     },
 
     initialize: function(points, options) {
@@ -38,7 +39,7 @@ L.CanvasLayer.SimpleLonLat = L.CanvasLayer.extend({
             let p = viewInfo.layer._map.latLngToContainerPoint(point);
             g.beginPath();
             //g.arc(p.x, p.y, 1, 0, Math.PI * 2); // circle | TODO style 'function' as parameter?
-            g.fillRect(p.x, p.y, 2, 2); //simple point
+            g.fillRect(p.x, p.y, this.options.size, this.options.size); //simple point
             g.fill();
             g.closePath();
             g.stroke();


### PR DESCRIPTION
Hello, I am submitting a very small change to allow the size of grid points (in `L.CanvasLayer.SimpleLonLat.js`) to be defined as a parameter.

Thanks for creating the option of showing grid points. Being able to choose the nearest grid point of a desired location is a very useful option but I never saw this in another plugin.